### PR TITLE
MAINT: Upgrade to Django 1.10.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.10
+Django==1.10.5
 
 # Configuration
 django-environ==0.4.0


### PR DESCRIPTION
Scrolling through changelogs from 1.10 to 1.10.5 I saw only bug fixes, and no API changes, so I think it should work just to tweak the requirements?

Resolves #67