### PR TITLE
BUG: Disabling extended cookie validation for now

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -66,7 +66,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'payments.middleware.CookieValidationMiddleware'
 ]
 
 ROOT_URLCONF = 'config.urls.payments'


### PR DESCRIPTION
Related to https://github.com/qiime2/workshops.qiime2.org/pull/89.

A user is currently reporting that they are unable to access discount-code protected rates, sounds like it is related to this middleware.